### PR TITLE
Handle when testcase_result.params is None

### DIFF
--- a/dump2polarion/exporter.py
+++ b/dump2polarion/exporter.py
@@ -165,7 +165,7 @@ class XunitExport(object):
                  'value': utils.get_unicode_str(result['comment'])}
             )
 
-        for param, value in six.iteritems(result.get('params', {})):
+        for param, value in six.iteritems(result.get('params', {}) or {}):
             ElementTree.SubElement(
                 properties,
                 'property',


### PR DESCRIPTION
Use an empty dictionary when result.params is None.



FIXES #1 