### PR TITLE
Remove zfill of version number on testrun name generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 lxml
 mock
+packaging
 pre-commit
 pytest
 pytest-cov

--- a/tests/test_ostriztools.py
+++ b/tests/test_ostriztools.py
@@ -42,14 +42,14 @@ class TestOstriz(object):
         testrun_id = ostriztools._get_testrun_id("5.8.0.17-20170525183055_6317a22")
         assert testrun_id == "5_8_0_17"
 
-    def test_testrun_id_fill(self):
+    def test_testrun_id_nofill(self):
         testrun_id = ostriztools._get_testrun_id("5.8.0.7-2017")
-        assert testrun_id == "5_8_0_07"
+        assert testrun_id == "5_8_0_7"
 
     def test_testrun_id_invalid(self):
         with pytest.raises(Dump2PolarionException) as excinfo:
             ostriztools._get_testrun_id("INVALID")
-        assert "Cannot find testrun id" in str(excinfo.value)
+        assert "InvalidVersion parsing testrun ID" in str(excinfo.value)
 
     def test_duration_good(self):
         duration = ostriztools._calculate_duration(1495766591.151192, 1495768544.573208)


### PR DESCRIPTION
CFME QE would like to stop zfilling testrun ID's last build number, and instead use the version number itself (with '_' replacement) for the testrun ID.  Since this was hardcoded, when we tried to upload results to polarion it was automatically adding a new testrun with a double-zero ID.

@mkoura I'm interested in your thoughts on the impact here, and if I should instead build up some logic around this lookup for non-zfill testrun ID's.