### PR TITLE
Update ostriztools, version formatting

### DIFF
--- a/dump2polarion/results/ostriztools.py
+++ b/dump2polarion/results/ostriztools.py
@@ -51,17 +51,16 @@ def _get_testrun_id(version):
     Then use packaging Version to parse the version string
     Then cast each release component to string for joining with _
 
-    Build and returns testrun ID that looks like x_y_z_a from version x.y.z.a-20181114_abcdef
+    Build and returns testrun ID that looks like x.y.z.a from version x.y.z.a-20181114_abcdef
     """
     try:
         v = Version(version.split("-")[0].split("_")[0])
-        build_base = "_".join([str(i) for i in v.release])
     except InvalidVersion:
         raise Dump2PolarionException("InvalidVersion parsing testrun ID from {}".format(version))
     except Exception:
         # not in expected format
         raise Dump2PolarionException("Exception parsing testrun ID from {}".format(version))
-    return build_base
+    return v.vstring
 
 
 def _calculate_duration(start_time, finish_time):

--- a/tests/test_ostriztools.py
+++ b/tests/test_ostriztools.py
@@ -36,15 +36,15 @@ def records_json_search():
 class TestOstriz(object):
     def test_testrun_id_simple(self):
         testrun_id = ostriztools._get_testrun_id("5.8.0.17")
-        assert testrun_id == "5_8_0_17"
+        assert testrun_id == "5.8.0.17"
 
     def test_testrun_id_build(self):
         testrun_id = ostriztools._get_testrun_id("5.8.0.17-20170525183055_6317a22")
-        assert testrun_id == "5_8_0_17"
+        assert testrun_id == "5.8.0.17"
 
     def test_testrun_id_nofill(self):
         testrun_id = ostriztools._get_testrun_id("5.8.0.7-2017")
-        assert testrun_id == "5_8_0_7"
+        assert testrun_id == "5.8.0.7"
 
     def test_testrun_id_invalid(self):
         with pytest.raises(Dump2PolarionException) as excinfo:
@@ -68,7 +68,7 @@ class TestOstriz(object):
         assert len(records_json.results) == 6
         assert "title" in records_json.results[0]
         assert hasattr(records_json, "testrun")
-        assert records_json.testrun == "5_8_0_17"
+        assert records_json.testrun == "5.8.0.17"
 
     def test_invalid_json(self):
         fname = "junit-report.xml"
@@ -113,7 +113,7 @@ class TestOstriz(object):
         assert complete == parsed
 
     def test_e2e_ids_transform(self, config_prop, records_json):
-        exporter = XunitExport("5_8_0_17", records_json, config_prop)
+        exporter = XunitExport("5.8.0.17", records_json, config_prop)
         complete = exporter.export()
         fname = "ostriz_transform.xml"
         with io.open(os.path.join(conf.DATA_PATH, fname), encoding="utf-8") as input_xml:
@@ -121,7 +121,7 @@ class TestOstriz(object):
         assert complete == parsed
 
     def test_e2e_cmp_ids_transform(self, config_prop_cmp, records_json_cmp):
-        exporter = XunitExport("5_8_0_17", records_json_cmp, config_prop_cmp)
+        exporter = XunitExport("5.8.0.17", records_json_cmp, config_prop_cmp)
         complete = exporter.export()
         fname = "ostriz_transform_cmp.xml"
         with io.open(os.path.join(conf.DATA_PATH, fname), encoding="utf-8") as input_xml:
@@ -129,7 +129,7 @@ class TestOstriz(object):
         assert complete == parsed
 
     def test_e2e_ids_search_transform(self, config_prop, records_json_search):
-        exporter = XunitExport("5_8_0_17", records_json_search, config_prop)
+        exporter = XunitExport("5.8.0.17", records_json_search, config_prop)
         complete = exporter.export()
         fname = "ostriz_search_transform.xml"
         with io.open(os.path.join(conf.DATA_PATH, fname), encoding="utf-8") as input_xml:


### PR DESCRIPTION
Don't replace '.' with '_' in version name, just use vstring with dotted version

If we don't want to completely strip this, I can add a CLI option to control this replacement?