### PR TITLE
Update RequirementExport._classify_data to process pythonic keys

### DIFF
--- a/dump2polarion/exporters/requirements_exporter.py
+++ b/dump2polarion/exporters/requirements_exporter.py
@@ -128,12 +128,13 @@ class RequirementExport(object):
         attrs, custom_fields = {}, {}
 
         for key, value in six.iteritems(req_data):
+            conv_key = key.replace('_', '-')  # convert pythonic key_param to polarion 'key-param'
             if not value:
                 continue
-            if key in self.REQ_DATA:
-                attrs[key] = value
-            elif key in self.CUSTOM_FIELDS:
-                custom_fields[key] = value
+            if conv_key in self.REQ_DATA:
+                attrs[conv_key] = value
+            elif conv_key in self.CUSTOM_FIELDS:
+                custom_fields[conv_key] = value
 
         return attrs, custom_fields
 


### PR DESCRIPTION
Take pythonic keys from requirement marker definition (assignee_id) and convert to the polarion compatible requirement field (assignee-id)

Tested successfully with assignee-id and the CFME project in the staging instance of polarion.