### PR TITLE
Support status-id in testcase export

### DIFF
--- a/dump2polarion/exporters/testcases_exporter.py
+++ b/dump2polarion/exporters/testcases_exporter.py
@@ -8,7 +8,7 @@ testcases_data = [
         "id": "ITEM01",
         "title": "test_manual",
         "description": "Manual tests with all supported fields.",
-        "approver-ids": "mkourim:approved",
+        "approver-ids": "bossman mkourim:approved",
         "assignee-id": "mkourim",
         "due-date": "2018-09-30",
         "initial-estimate": "1/4h",
@@ -27,6 +27,7 @@ testcases_data = [
         "testSteps": ["step1", "step2"],
         "expectedResults": ["result1", "result2"],
         "linked-items": "ITEM01",
+        "status-id": "proposed",
     },
     {
         "title": "test_minimal_param",
@@ -62,6 +63,7 @@ class TestcaseTransform(object):
         "due-date": None,
         "id": None,
         "initial-estimate": None,
+        "status-id": None,
     }
 
     FIELD_MAPPING = {"assignee-id": "assignee", "initial-estimate": "initialEstimate"}


### PR DESCRIPTION
Very simple change that includes `status-id` field in testcase data. Does not need key translation, tested on RH stage polarion instance with RHCF3 project.

Update example to show syntax for multiple `approver-ids`

On import, the work item is transitioned to the desired state, including `approved`.

These transitions are still limited by the workflow restrictions that polarion imposes. 

```
2019-09-09 16:45:54,068 INFO ImportTestcaseThread_377 - Changing work item status from 'draft' to 'proposed'.
2019-09-09 16:45:54,252 INFO ImportTestcaseThread_377 - Changing work item status from 'proposed' to 'approved'.
2019-09-09 16:45:54,315 ERROR ImportTestcaseThread_377 - Script(isReqLink.js) Workflow condition fails: Test needs at least one linked work item of type Requirement or be marked as a Legacy Test Case
2019-09-09 16:45:54,315 ERROR ImportTestcaseThread_377 - Unable to set work item status to 'approved', currently 'proposed'.
```