### PR TITLE
Add placeholder description text

### DIFF
--- a/dump2polarion/exporters/transform.py
+++ b/dump2polarion/exporters/transform.py
@@ -188,8 +188,9 @@ def add_unique_runid(testcase, run_id=None):
     The `run_id` runs makes the descriptions unique between imports and force Polarion
     to update every testcase every time.
     """
-    testcase["description"] = '{}<br id="{}"/>'.format(
-        testcase.get("description") or "", run_id or id(add_unique_runid)
+    testcase["description"] = '{visible}<br id="{invisible}"/>'.format(
+        visible=testcase.get("description") or "empty-description-placeholder",
+        invisible=run_id or id(add_unique_runid)
     )
 
 

--- a/tests/data/testcase_complete_cfme.xml
+++ b/tests/data/testcase_complete_cfme.xml
@@ -38,7 +38,7 @@ Manual tests with many supported fields.
   </testcase>
   <testcase id="test_minimal_param" initial-estimate="1m">
     <title>test_minimal_param</title>
-    <description>&lt;br id="id123"/&gt;&lt;br/&gt;</description>
+    <description>empty-description-placeholder&lt;br id="id123"/&gt;&lt;br/&gt;</description>
     <test-steps>
       <test-step>
         <test-step-column id="step"/>

--- a/tests/data/testcase_complete_cfme_param.xml
+++ b/tests/data/testcase_complete_cfme_param.xml
@@ -38,7 +38,7 @@ Manual tests with many supported fields.
   </testcase>
   <testcase id="test_minimal_param" initial-estimate="1m">
     <title>test_minimal_param</title>
-    <description>&lt;br id="id123"/&gt;&lt;br/&gt;</description>
+    <description>empty-description-placeholder&lt;br id="id123"/&gt;&lt;br/&gt;</description>
     <test-steps>
       <test-step>
         <test-step-column id="step">

--- a/tests/data/testcase_fields_cfme.xml
+++ b/tests/data/testcase_fields_cfme.xml
@@ -39,7 +39,7 @@ Manual tests with many supported fields.
   </testcase>
   <testcase id="test_minimal_param">
     <title>test_minimal_param</title>
-    <description>&lt;br id="id123"/&gt;&lt;br/&gt;</description>
+    <description>empty-description-placeholder&lt;br id="id123"/&gt;&lt;br/&gt;</description>
     <test-steps>
       <test-step>
         <test-step-column id="step"/>


### PR DESCRIPTION
Default the description to a placeholder string, instead of an empty string. Polarion prevents test cases with empty descriptions from being set to status-id proposed, which I would like to circumvent here.