### PR TITLE
Update processing of ostriz blockers

### DIFF
--- a/dump2polarion/exporters/transform_projects.py
+++ b/dump2polarion/exporters/transform_projects.py
@@ -42,6 +42,8 @@ def get_xunit_transform_cfme(config):
         "BZ ?[0-9]+",
         "GH ?#?[0-9]+",
         "GH#ManageIQ",
+        r"bugzilla\.redhat\.com",
+        r"github\.com",
     ]
     skips = re.compile("(" + ")|(".join(skip_searches) + ")")
 


### PR DESCRIPTION
I'm not sure if this was ever processing "correctly" for how ostriz is storing skip data.

The way that its stored isn't ideal, and as a result there are some messy assumptions here.

This has been tested on stage polarion for RHCF3, but needs some discussion. 
Maybe acceptable as a patch for current processing, to push blocked results.